### PR TITLE
[fix] dividends and utc dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yahoo-stock-api",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Simple package to get stock price from yahoo finance",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,18 +81,19 @@ class YahooStockAPI {
     private getHistoricalPricesMapRows(_, row): HistoricalPricesResponse {
         const obj = { date: null, open: null, high: null, low: null, close: null, adjClose: null, volume: null };
         const columns = ['date', 'open', 'high', 'low', 'close', 'adjClose', 'volume'];
-        cheerio.load(row)('td').map((index, cell: any) => {
-            cell = cheerio.load(cell);
+        const $row = cheerio.load(row);
+
+        $row('td').each((index, cell: any) => {
+            const text = $row(cell).text();
             const selector = columns[index];
-            switch(index) {
-                case 0:
-                    obj[selector] = new Date(cell.text()).getTime() / 1000;
-                    break;
-                default:
-                    obj[selector] = numeral(cell.text()).value();
-                    break;
+
+            if (index === 0) {
+                obj[selector] = new Date(`${text} 00:00:00 +0000`).getTime() / 1000;
+            } else {
+                obj[selector] = numeral(text).value();
             }
         });
+
         return obj;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,16 @@ class YahooStockAPI {
             currency = currency ? currency.split('.')[1].replace('Currency in', '').trim() : undefined;
             const name: string = this.getTidyName($('h1').text());
             const response = $('#Col1-1-HistoricalDataTable-Proxy > section > div:nth-child(2) > table > tbody > tr').map(this.getHistoricalPricesMapRows).get();
+            // filter out null values (dividend pays)
+            const columns = ['date', 'open', 'high', 'low', 'close', 'adjClose', 'volume'];
+            const filteredResponse = response.filter((obj) => {
+                return !columns.some((column) => obj[column] == null);
+            });
             return {
                 error: false,
                 currency: currency || undefined,
                 name: name || undefined,
-                response,
+                response: filteredResponse,
             };
         }
         catch(err) {


### PR DESCRIPTION
Some stocks would get dividend pays in the page, like this:
![image](https://github.com/phamleduy04/yahoo-stock-api/assets/2657230/89792056-9f9f-4bcd-958b-1756562d484c)

The `filter` logic should take care of that part.

Also, the dates were subject to the user/server timezone, now they are UTC, they look like `2023-08-07T00:00:00.000Z` in any timezone